### PR TITLE
feat(volunteer): add one-off tag to sidebar and improve back navigation

### DIFF
--- a/app/(withLayout)/volunteer/opportunities/[id]/page.tsx
+++ b/app/(withLayout)/volunteer/opportunities/[id]/page.tsx
@@ -3,24 +3,24 @@
 import { ArrowLeft } from "lucide-react";
 import { PostContent } from "@/components/layout/volunteer/homepage/PostContent";
 import { Sidebar } from "@/components/layout/volunteer/homepage/Sidebar";
-import { useRouter, useParams } from "next/navigation";
+import { useParams } from "next/navigation";
 import ProtectedLayout from "@/components/layout/ProtectedLayout";
+import Link from "next/link";
 
 export default function OpportunityDetailPage() {
-  const router = useRouter();
   const params = useParams();
   const opportunityId = Array.isArray(params?.id) ? params.id[0] : params?.id;
 
   if (!opportunityId || !["1", "2", "3", "4"].includes(opportunityId)) {
     return (
       <div className="max-w-[1280px] mx-auto px-4 mb-8 pt-20">
-        <button
-          onClick={() => router.back()}
-          className="flex items-center gap-2 cursor-pointer text-gray-600 mb-6"
+        <Link 
+          href="/volunteer" 
+          className="flex items-center gap-2 cursor-pointer text-gray-600 mb-6 hover:text-blue-600"
         >
           <ArrowLeft className="w-4 h-4" />
           Back
-        </button>
+        </Link>
         <div className="text-center">
           <h1 className="text-2xl font-bold">Opportunity not found</h1>
           <p className="text-gray-600 mt-2">
@@ -34,14 +34,14 @@ export default function OpportunityDetailPage() {
   return (
     <ProtectedLayout>
       <div className="flex flex-col min-h-screen">
-       <div className="flex-1 max-w-[1280px] mx-auto px-4 mb-8 pt-20">
-        <button
-          onClick={() => router.back()}
-          className="flex items-center gap-2 text-gray-600 mb-6"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Back
-        </button>
+        <div className="flex-1 max-w-[1280px] mx-auto px-4 mb-8 pt-20">
+          <Link 
+            href="/volunteer" 
+            className="flex items-center gap-2 text-gray-600 mb-6 hover:text-blue-600"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back
+          </Link>
         <div className="flex flex-col lg:flex-row gap-8 justify-between">
           <div className="flex-1">
             <PostContent opportunityId={opportunityId} />

--- a/components/layout/volunteer/homepage/HomePageCategories.tsx
+++ b/components/layout/volunteer/homepage/HomePageCategories.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
@@ -12,7 +12,7 @@ import { trpc } from "@/utils/trpc";
 import fileIcon from "../../../../public/icons/file-icon.svg";
 import mapPinIcon from "../../../../public/icons/map-pin-icon.svg";
 import mapPinGrayIcon from "../../../../public/icons/map-pin-gray-icon.svg";
-import { Star } from "lucide-react";
+import { Star, Users } from "lucide-react";
 
 type OpportunityDetails = {
   id: string;
@@ -59,6 +59,8 @@ export default function Categories({
       description:
         "Do you have a passion for gardening and a desire to make a real difference in your community? We are looking for enthusiastic and friendly volunteers to help senior Australians maintain their gardens and stay in the homes they love. As a volunteer gardener, you'll work in a team to provide essential gardening services such as weeding, pruning, and mulching. Your efforts will directly contribute to creating safe and tidy outdoor spaces for elderly individuals, helping them to live independently for longer.",
       logoSrc: "/Easy.svg",
+      totalSpots: 10,
+      spotsAvailable: 8
     },
     {
       id: "4",
@@ -75,6 +77,8 @@ export default function Categories({
       description:
         "Do you have a passion for gardening and a desire to make a real difference in your community? We are looking for enthusiastic and friendly volunteers to help senior Australians maintain their gardens and stay in the homes they love. As a volunteer gardener, you'll work in a team to provide essential gardening services such as weeding, pruning, and mulching. Your efforts will directly contribute to creating safe and tidy outdoor spaces for elderly individuals, helping them to live independently for longer.",
       logoSrc: "/Easy.svg",
+      totalSpots: 10,
+      spotsAvailable: 7
     },
     {
       id: "2",
@@ -91,8 +95,9 @@ export default function Categories({
       description:
         "Want to help protect Australia's parks, beaches, and waterways from litter and waste? Clean Up Australia is looking for enthusiastic volunteers to help clean up general waste from our parks, beaches, and other public spaces. As a volunteer, you'll join a nationwide movement of people dedicated to keeping Australia clean and healthy. You'll work together to remove litter, protect our natural environment, and make a positive impact on your local community.",
       logoSrc: "/Clean.svg",
+      totalSpots: 20,
+      spotsAvailable: 15
     },
-   
     {
       id: "3",
       title: "Clean Up Australia",
@@ -108,6 +113,8 @@ export default function Categories({
       description:
         "Want to help protect Australia's parks, beaches, and waterways from litter and waste? Clean Up Australia is looking for enthusiastic volunteers to help clean up general waste from our parks, beaches, and other public spaces. As a volunteer, you'll join a nationwide movement of people dedicated to keeping Australia clean and healthy",
       logoSrc: "/Clean.svg",
+      totalSpots: 20,
+      spotsAvailable: 12
     },
   ];
 
@@ -133,13 +140,23 @@ export default function Categories({
           >
             <CardContent className="px-4 pt-4">
               <div className="space-y-3">
-                <Image
-                  src={opportunity.logoSrc}
-                  alt={opportunity.organization}
-                  width={40}
-                  height={40}
-                  className="rounded-full"
-                />
+                <div className="flex justify-between items-center">
+                  <Image
+                    src={opportunity.logoSrc}
+                    alt={opportunity.organization}
+                    width={40}
+                    height={40}
+                    className="rounded-full"
+                  />
+                  <div className="flex items-center gap-2">
+                    <div className="flex items-center text-gray-600">
+                      <Users className="h-5 w-5 mr-1" />
+                      <span className="text-sm">
+                        <span className="font-medium text-green-600">{opportunity.spotsAvailable}</span> of <span className="font-medium">{opportunity.totalSpots}</span> spots left
+                      </span>
+                    </div>
+                  </div>
+                </div>
 
                 <h3 className="text-lg font-semibold line-clamp-1">
                   {opportunity.title}
@@ -194,15 +211,11 @@ export default function Categories({
                   </div>
                 </div>
 
-                <div className="text-sm text-gray-600 line-clamp-4">
-                  {opportunity.description}
-                  <Link
-                    href={`/volunteer/opportunities/${opportunity.id}`}
-                    className="text-blue-600 hover:text-blue-700 text-sm ml-1"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    Read more
-                  </Link>
+                <div className="space-y-1">
+                  <div className="text-sm text-gray-600 line-clamp-3">
+                    {opportunity.description}
+                  </div>
+                 
                 </div>
               </div>
             </CardContent>

--- a/components/layout/volunteer/homepage/Sidebar.tsx
+++ b/components/layout/volunteer/homepage/Sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { MapPin, Calendar, Clock } from "lucide-react";
+import { MapPin, Calendar, Clock, Tag } from "lucide-react";
 import Image from "next/image";
 
 interface OpportunityDetails {
@@ -83,6 +83,11 @@ export function Sidebar({ opportunityId }: { opportunityId?: string }) {
           <div className="flex items-center gap-2 text-gray-600">
             <MapPin className="w-5 h-5 text-blue-500" />
             <span>{details.location}</span>
+          </div>
+
+          <div className="flex items-center gap-2 text-gray-600">
+            <Tag className="w-5 h-5 text-blue-500" />
+            <span>One-off</span>
           </div>
 
           <div className="flex items-center gap-2 text-gray-600">


### PR DESCRIPTION
- Added a "One-off" tag to the volunteer opportunity sidebar using the `Tag` icon from lucide-react
- Replaced `router.back()` with a `Link` component for consistent and reliable back navigation
- Added spots available and total spots information to the volunteer opportunity cards