### PR TITLE
refactor(messages): eliminate stale time for real-time updates

### DIFF
--- a/components/navbar/TopNavigationBar.tsx
+++ b/components/navbar/TopNavigationBar.tsx
@@ -33,7 +33,7 @@ export default function TopNavigationBar() {
     undefined,
     {
       enabled: isAuthenticated,
-      staleTime: 5 * 60 * 1000, // 5 minutes stale time
+      staleTime: 0, // No stale time to allow immediate updates via SSE
       refetchOnWindowFocus: false, // Disable refetch on window focus
       refetchOnMount: true,
       refetchInterval: false, // Disable polling - rely on SSE for real-time updates
@@ -45,7 +45,7 @@ export default function TopNavigationBar() {
     undefined,
     {
       enabled: isAuthenticated,
-      staleTime: 5 * 60 * 1000, // 5 minutes stale time
+      staleTime: 0, // No stale time to allow immediate updates via SSE
       refetchOnWindowFocus: false, // Disable refetch on window focus
       refetchOnMount: true,
       refetchInterval: false, // Disable polling - rely on SSE for real-time updates

--- a/hooks/useConversations.ts
+++ b/hooks/useConversations.ts
@@ -8,7 +8,7 @@ export const useConversations = () => {
   const { data: conversations, isLoading: isLoadingConversations } =
     trpc.messages.getConversations.useQuery(undefined, {
       enabled: !!session?.user?.id,
-      staleTime: 5 * 60 * 1000, // 5 minutes stale time
+      staleTime: 0, // No stale time to allow immediate updates via SSE
       refetchOnWindowFocus: false, // Disable refetch on window focus
       refetchOnMount: true,
       refetchInterval: false, // Disable polling - rely on SSE for real-time updates
@@ -17,7 +17,7 @@ export const useConversations = () => {
   const { data: groups, isLoading: isLoadingGroups } =
     trpc.messages.getGroups.useQuery(undefined, {
       enabled: !!session?.user?.id,
-      staleTime: 5 * 60 * 1000, // 5 minutes stale time
+      staleTime: 0, // No stale time to allow immediate updates via SSE
       refetchOnWindowFocus: false, // Disable refetch on window focus
       refetchOnMount: true,
       refetchInterval: false, // Disable polling - rely on SSE for real-time updates

--- a/hooks/useGlobalSSE.ts
+++ b/hooks/useGlobalSSE.ts
@@ -181,14 +181,26 @@ export const useGlobalSSE = () => {
         }
       }
       
-      // Always update conversations and groups lists for sidebar
+      // Update conversations and groups lists for sidebar
       utils.messages.getConversations.invalidate();
       utils.messages.getGroups.invalidate();
+      
+      // Also invalidate all message queries to ensure UI updates
+      // This ensures that any open conversation will show the new message
+      if (messageData.group) {
+        // For group messages, invalidate group messages query
+        utils.messages.getGroupMessages.invalidate();
+      } else {
+        // For direct messages, invalidate direct messages query
+        utils.messages.getMessages.invalidate();
+      }
     }
     
     if (data.type === 'message_read') {
       // Update read status
       utils.messages.getConversations.invalidate();
+      utils.messages.getMessages.invalidate();
+      utils.messages.getGroupMessages.invalidate();
     }
   }, [session?.user?.id, utils]);
 

--- a/hooks/useMessages.ts
+++ b/hooks/useMessages.ts
@@ -24,7 +24,7 @@ export const useMessages = (selectedUserId: string | null, isGroup: boolean) => 
         getNextPageParam: (lastPage) => lastPage.nextCursor,
         refetchOnWindowFocus: false, // Disable refetch on window focus
         refetchOnMount: true,
-        staleTime: 5 * 60 * 1000, // 5 minutes stale time
+        staleTime: 0, // No stale time to allow immediate updates via SSE
         refetchInterval: false, // Disable polling - rely on SSE for real-time updates
       }
     );
@@ -39,7 +39,7 @@ export const useMessages = (selectedUserId: string | null, isGroup: boolean) => 
         getNextPageParam: (lastPage) => lastPage.nextCursor,
         refetchOnWindowFocus: false, // Disable refetch on window focus
         refetchOnMount: true,
-        staleTime: 5 * 60 * 1000, // 5 minutes stale time
+        staleTime: 0, // No stale time to allow immediate updates via SSE
         refetchInterval: false, // Disable polling - rely on SSE for real-time updates
       }
     );


### PR DESCRIPTION
- Updated `useConversations`, `useMessages`, and `TopNavigationBar` hooks to set stale time to 0, allowing immediate updates via Server-Sent Events (SSE).
- Enhanced `useGlobalSSE` to invalidate message queries for real-time UI updates, ensuring that conversations reflect new messages promptly.