### PR TITLE
feat(ui): limit displayed categories and show "+n more" badge

### DIFF
--- a/components/Categories.tsx
+++ b/components/Categories.tsx
@@ -146,7 +146,7 @@ export default function Categories() {
           </div>
 
           <div className="flex flex-wrap gap-1 mb-3">
-            {opportunity.categories.map((category, idx) => (
+            {opportunity.categories.slice(0, 1).map((category, idx) => (
               <Badge
                 key={idx}
                 variant="secondary"
@@ -155,6 +155,14 @@ export default function Categories() {
                 {category}
               </Badge>
             ))}
+            {opportunity.categories.length > 1 && (
+              <Badge
+                variant="secondary"
+                className="text-xs font-normal text-gray-500"
+              >
+                +{opportunity.categories.length - 1} more
+              </Badge>
+            )}
           </div>
 
           <p className="text-sm text-gray-600 mb-4">

--- a/components/layout/organisation/dashboard/index.tsx
+++ b/components/layout/organisation/dashboard/index.tsx
@@ -374,7 +374,7 @@ const OrganisationDashboard = () => {
                             ? "Work based"
                             : "Event based"}
                         </Badge>
-                        {opportunity.category.map(
+                        {opportunity.category.slice(0, 1).map(
                           (cat: string, index: number) => (
                             <Badge
                               key={index}
@@ -384,6 +384,14 @@ const OrganisationDashboard = () => {
                               {cat}
                             </Badge>
                           )
+                        )}
+                        {opportunity.category.length > 1 && (
+                          <Badge
+                            variant="secondary"
+                            className="text-xs font-normal text-gray-500"
+                          >
+                            +{opportunity.category.length - 1} more
+                          </Badge>
                         )}
                       </div>
 

--- a/components/layout/volunteer/find-opportunity/OpportunityCard.tsx
+++ b/components/layout/volunteer/find-opportunity/OpportunityCard.tsx
@@ -76,7 +76,7 @@ export default function OpportunityCard({
           </div>
 
           <div className="flex flex-wrap gap-2">
-            {opportunity.category.map((category, idx) => (
+            {opportunity.category.slice(0, 1).map((category, idx) => (
               <Badge
                 key={idx}
                 variant="secondary"
@@ -85,6 +85,14 @@ export default function OpportunityCard({
                 {category}
               </Badge>
             ))}
+            {opportunity.category.length > 1 && (
+              <Badge
+                variant="secondary"
+                className="text-xs font-normal bg-gray-100 text-gray-500 hover:bg-gray-200"
+              >
+                +{opportunity.category.length - 1} more
+              </Badge>
+            )}
           </div>
 
           <div

--- a/components/layout/volunteer/home-page/HomePageCategories.tsx
+++ b/components/layout/volunteer/home-page/HomePageCategories.tsx
@@ -7,7 +7,6 @@ import { ApplyButton } from "@/components/buttons/ApplyButton";
 import { FavoriteButton } from "@/components/buttons/FavoriteButton";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import mapPinGrayIcon from "../../../../public/icons/map-pin-gray-icon.svg";
 import { trpc } from "@/utils/trpc";
 import fileIcon from "../../../../public/icons/file-icon.svg";
 import mapPinIcon from "../../../../public/icons/map-pin-icon.svg";
@@ -229,7 +228,7 @@ export default function Categories() {
                 </div>
 
                 <div className="flex flex-wrap gap-1">
-                  {opportunity.category.map((category: string, idx: number) => (
+                  {opportunity.category.slice(0, 1).map((category: string, idx: number) => (
                     <Badge
                       key={idx}
                       variant="secondary"
@@ -238,18 +237,14 @@ export default function Categories() {
                       {category}
                     </Badge>
                   ))}
-                  <div className="flex items-center w-[150px] rounded-[4px] bg-[#EBF8F4] p-1">
-                    <Image
-                      src={mapPinGrayIcon}
-                      height={16}
-                      width={16}
-                      className="mr-1"
-                      alt="Map pin gray icon"
-                    />
-                    <span className="text-sm text-green-600">
-                      Matching location
-                    </span>
-                  </div>
+                  {opportunity.category.length > 1 && (
+                    <Badge
+                      variant="secondary"
+                      className="text-sm bg-[#F0F0F0] rounded-[4px] font-normal text-gray-500"
+                    >
+                      +{opportunity.category.length - 1} more
+                    </Badge>
+                  )}
                 </div>
 
                 <div className="space-y-1">

--- a/components/layout/volunteer/home-page/HomePageSuggestions.tsx
+++ b/components/layout/volunteer/home-page/HomePageSuggestions.tsx
@@ -114,11 +114,16 @@ export default function HomePageSuggestions() {
                     </div>
 
                     <div className="flex flex-wrap gap-1 mb-2">
-                      {opportunity.categories.map((category, idx) => (
+                      {opportunity.categories.slice(0, 1).map((category, idx) => (
                         <Badge key={idx} variant="secondary" className="text-[10px] md:text-xs font-normal">
                           {category}
                         </Badge>
                       ))}
+                      {opportunity.categories.length > 1 && (
+                        <Badge variant="secondary" className="text-[10px] md:text-xs font-normal text-gray-500">
+                          +{opportunity.categories.length - 1} more
+                        </Badge>
+                      )}
                     </div>
 
                     <p className="text-xs md:text-sm text-gray-600 mb-2 line-clamp-2 md:line-clamp-3">

--- a/components/layout/volunteer/home-page/OrganizationOpportunities.tsx
+++ b/components/layout/volunteer/home-page/OrganizationOpportunities.tsx
@@ -7,7 +7,6 @@ import { ApplyButton } from "@/components/buttons/ApplyButton";
 import { FavoriteButton } from "@/components/buttons/FavoriteButton";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import mapPinGrayIcon from "../../../../public/icons/map-pin-gray-icon.svg";
 import { trpc } from "@/utils/trpc";
 import fileIcon from "../../../../public/icons/file-icon.svg";
 import mapPinIcon from "../../../../public/icons/map-pin-icon.svg";
@@ -331,7 +330,7 @@ export default function OrganizationOpportunities({
                   </div>
 
                   <div className="flex flex-wrap gap-1">
-                    {opportunity.category.map(
+                    {opportunity.category.slice(0, 1).map(
                       (category: string, idx: number) => (
                         <Badge
                           key={idx}
@@ -342,18 +341,14 @@ export default function OrganizationOpportunities({
                         </Badge>
                       )
                     )}
-                    <div className="flex items-center w-[150px] rounded-[4px] bg-[#EBF8F4] p-1">
-                      <Image
-                        src={mapPinGrayIcon}
-                        height={16}
-                        width={16}
-                        className="mr-1"
-                        alt="Map pin gray icon"
-                      />
-                      <span className="text-sm text-green-600">
-                        Matching location
-                      </span>
-                    </div>
+                    {opportunity.category.length > 1 && (
+                      <Badge
+                        variant="secondary"
+                        className="text-sm bg-[#F0F0F0] rounded-[4px] font-normal text-gray-500"
+                      >
+                        +{opportunity.category.length - 1} more
+                      </Badge>
+                    )}
                   </div>
 
                   <div className="space-y-1">


### PR DESCRIPTION
Modify multiple components to display only the first category and show a "+n more" badge when there are additional categories. This improves UI consistency and prevents category overflow in cards.