### PR TITLE
perf: increase polling frequency for real-time updates

### DIFF
--- a/components/navbar/TopNavigationBar.tsx
+++ b/components/navbar/TopNavigationBar.tsx
@@ -36,7 +36,7 @@ export default function TopNavigationBar() {
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false,
       refetchOnMount: true,
-      refetchInterval: 60000, // Poll every 60 seconds for new conversations
+      refetchInterval: 15000, // Poll every 15 seconds for new conversations
     }
   );
 
@@ -48,7 +48,7 @@ export default function TopNavigationBar() {
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false,
       refetchOnMount: true,
-      refetchInterval: 60000, // Poll every 60 seconds for new groups
+      refetchInterval: 15000, // Poll every 15 seconds for new groups
     }
   );
 
@@ -64,14 +64,6 @@ export default function TopNavigationBar() {
   ) || 0;
 
   const totalUnreadCount = conversationsUnreadCount + groupsUnreadCount;
-
-  console.log('🔍 TopNavigationBar unread counts:', {
-    conversationsUnreadCount,
-    groupsUnreadCount,
-    totalUnreadCount,
-    conversationsCount: conversations?.length || 0,
-    groupsCount: groups?.length || 0
-  });
 
   // Handle client-side mounting
   useEffect(() => {

--- a/hooks/useConversations.ts
+++ b/hooks/useConversations.ts
@@ -12,7 +12,7 @@ export const useConversations = () => {
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false,
       refetchOnMount: true,
-      refetchInterval: 30000, // Poll every 30 seconds for new conversations
+      refetchInterval: 15000, // Poll every 15 seconds for new conversations
     });
 
   const { data: groups, isLoading: isLoadingGroups } =
@@ -21,23 +21,22 @@ export const useConversations = () => {
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false,
       refetchOnMount: true,
-      refetchInterval: 30000, // Poll every 30 seconds for new groups
+      refetchInterval: 15000, // Poll every 15 seconds for new groups
     });
-
-  console.log('🔍 useConversations hook state:', {
-    sessionUserId: session?.user?.id,
-    conversationsCount: conversations?.length || 0,
-    groupsCount: groups?.length || 0,
-    isLoadingConversations,
-    isLoadingGroups,
-    conversationsData: conversations?.slice(0, 2).map(c => ({ id: c._id, lastMessage: c.lastMessage?.content?.substring(0, 20) })),
-    groupsData: groups?.slice(0, 2).map(g => ({ id: g._id, lastMessage: g.lastMessage?.content?.substring(0, 20) }))
-  });
 
   const markAsReadMutation = trpc.messages.markAsRead.useMutation({
     onSuccess: () => {
+      // Invalidate and refetch all message-related queries to update unread counts
       utils.messages.getConversations.invalidate();
       utils.messages.getGroups.invalidate();
+      
+      // Also invalidate any infinite queries that might be cached
+      utils.messages.getMessages.invalidate();
+      utils.messages.getGroupMessages.invalidate();
+      
+      // Force refetch to ensure immediate update
+      utils.messages.getConversations.refetch();
+      utils.messages.getGroups.refetch();
     },
   });
 

--- a/hooks/useMessages.ts
+++ b/hooks/useMessages.ts
@@ -14,7 +14,7 @@ export const useMessages = (selectedUserId: string | null, isGroup: boolean) => 
       sessionUserId: session?.user?.id
     });
 
-    // Get messages with polling (every 15 seconds)
+    // Get messages with polling (every 10 seconds)
     const { data: messages, isLoading: isLoadingMessages, fetchNextPage, hasNextPage, isFetchingNextPage } = trpc.messages.getMessages.useInfiniteQuery(
       { 
         userId: selectedUserId || "",
@@ -26,7 +26,7 @@ export const useMessages = (selectedUserId: string | null, isGroup: boolean) => 
         refetchOnWindowFocus: false,
         refetchOnMount: true,
         staleTime: 5 * 60 * 1000, // 5 minutes
-        refetchInterval: 15000, // Poll every 15 seconds for new messages
+        refetchInterval: 10000, // Poll every 10 seconds for new messages
       }
     );
   
@@ -41,7 +41,7 @@ export const useMessages = (selectedUserId: string | null, isGroup: boolean) => 
         refetchOnWindowFocus: false,
         refetchOnMount: true,
         staleTime: 5 * 60 * 1000, // 5 minutes
-        refetchInterval: 15000, // Poll every 15 seconds for new messages
+        refetchInterval: 10000, // Poll every 10 seconds for new messages
       }
     );
 


### PR DESCRIPTION
- Reduce polling intervals from 60s to 15s for conversations and groups in TopNavigationBar
- Decrease message polling interval from 15s to 10s in useMessages hook
- Update conversation/group polling from 30s to 15s in useConversations
- Remove debug console logs and improve markAsRead mutation invalidation