### PR TITLE
fix(opportunity): correct population field name from "organisation_profile" to "organization_profile"

### DIFF
--- a/server/modules/opportunity/index.ts
+++ b/server/modules/opportunity/index.ts
@@ -191,7 +191,7 @@ export const opportunityRouter = router({
       const opportunities = await Opportunity.find({
         organization_profile: user.organization_profile,
       })
-        .populate("organisation_profile")
+        .populate("organization_profile")
         .sort({ createdAt: -1 });
 
       // Get applicant and recruit counts for each opportunity


### PR DESCRIPTION
…

- Updated the population field in the opportunity router to ensure consistency with the naming convention used throughout the application.